### PR TITLE
std.os.WriteError -> std.posix.WriteError

### DIFF
--- a/src/error.zig
+++ b/src/error.zig
@@ -7,7 +7,7 @@ pub const YazapError = error{ InvalidCmdLine, Overflow }
     || WriteError;
 // zig fmt: on
 pub const AllocatorError = std.mem.Allocator.Error;
-pub const WriteError = std.os.WriteError;
+pub const WriteError = std.posix.WriteError;
 pub const ParseError = error{
     UnknownFlag,
     UnknownCommand,


### PR DESCRIPTION
seems like `std.os.WriteError` was moved to `std.posix.WriteError` in https://github.com/ziglang/zig/commit/cd62005f19ff966d2c42de4daeb9a1e4b644bf76, causing this library to fail on latest master