### PR TITLE
Add `const` qualifier in `Command.addArgs` and `Command.addSubcommands`.

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -182,7 +182,7 @@ pub fn addSubcommand(self: *Command, new_subcommand: Command) !void {
 ///     app.createCommand("build", "Build the project"),
 /// });
 /// ```
-pub fn addSubcommands(self: *Command, subcommands: []Command) !void {
+pub fn addSubcommands(self: *Command, subcommands: []const Command) !void {
     for (subcommands) |subcmd| try self.addSubcommand(subcmd);
 }
 

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -144,7 +144,7 @@ pub fn addArg(self: *Command, new_arg: Arg) !void {
 ///     Arg.singleValueOption("postal", 'p', "Postal code"),
 /// });
 /// ```
-pub fn addArgs(self: *Command, args: []Arg) !void {
+pub fn addArgs(self: *Command, args: []const Arg) !void {
     for (args) |arg| try self.addArg(arg);
 }
 

--- a/src/arg_matches.zig
+++ b/src/arg_matches.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const Arg = @import("Arg.zig");
-const ArgHashMap = std.StringHashMap(MatchedArgValue);
+pub const ArgHashMap = std.StringHashMap(MatchedArgValue);
 
 pub const MatchedArgValue = union(enum) {
     none,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
 pub const App = @import("App.zig");
 pub const Arg = @import("Arg.zig");
-pub const ArgMatches = @import("arg_matches.zig").ArgMatches;
+pub const arg_matches = @import("arg_matches.zig");
+pub const ArgMatches = arg_matches.ArgMatches;
 pub const Command = @import("Command.zig");
 pub const YazapError = @import("error.zig").YazapError;
 


### PR DESCRIPTION
This will allow developers to add multiple constant arguments and subcommands to `*Command`.